### PR TITLE
Develop

### DIFF
--- a/routes/movie.route.js
+++ b/routes/movie.route.js
@@ -1,6 +1,9 @@
 const express = require('express');
+const passport = require('passport');
 
 const MovieController = require('../controllers/movie.controller');
+const ROLES = require('../utils/roles').ROLES;
+const checkIsInRole = require('../utils/auth').checkIsInRole;
 
 const router = express.Router();
 
@@ -23,7 +26,7 @@ router.param('/:id', (request, response, next) => {
 
 // The routes will need to be modified to reflect using the request body at some point.
 // Pass control (via callback) to MovieController.
-router.get('/:id', MovieController.getMovieById);
+router.get('/:id', passport.authenticate('jwt', { session: false }), checkIsInRole(ROLES.Customer), MovieController.getMovieById);
 
 router.post('/:title', MovieController.createMovie);
 

--- a/server.js
+++ b/server.js
@@ -9,9 +9,6 @@ const LocalStrategy = require('passport-local').Strategy;
 const JwtStrategy = require('passport-jwt').Strategy;
 const ExtractJwt = require('passport-jwt').ExtractJwt;
 
-const ROLES = require('./utils/roles').ROLES;
-const checkIsInRole = require('./utils/auth').checkIsInRole;
-
 const app = express();
 const port = process.env.PORT || 8000;
 
@@ -46,7 +43,7 @@ passport.serializeUser(User.serializeUser());
 passport.deserializeUser(User.deserializeUser());
 
 // Handles routes starting with '/movie'
-app.use('/movie', passport.authenticate('jwt', { session: false }), checkIsInRole(ROLES.Customer), movieRoutes);
+app.use('/movie', movieRoutes);
 app.use(userRoutes);
 
 // Configure db


### PR DESCRIPTION
I've moved route validation out of server.js, so not every route has to be validated. By placing the passport.authenticate(...) and checkIsInRole(...) inside the route file, we can specify specific routes for role-based authorisation whilst leaving other routes public.